### PR TITLE
Add config.mk parser and demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ core
 core.*
 
 *~
+
+# Python bytecode
+__pycache__/

--- a/flow/Makefile.py
+++ b/flow/Makefile.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+import sys
+
+import siliconcompiler
+
+mydir = os.path.dirname(__file__)
+scdir = os.path.join(mydir, 'scripts', 'sc')
+sys.path.append(os.path.join(scdir, 'util'))
+import parse_config_mk
+
+def main():
+    parser = argparse.ArgumentParser(description='Run OR flow through SiliconCompiler.')
+    parser.add_argument('-DESIGN_CONFIG', required=True, help='Path to config.mk file configuring design')
+    args = vars(parser.parse_args())
+
+    # Parse values out of provided "config.mk" file
+    # TODO: filled this out based on ./designs/nangate45/gcd/config.mk
+    # There are more possible variables and likely more complex possible values
+    # (such as multiple Verilog files)
+    config = parse_config_mk.parse(args['DESIGN_CONFIG'])
+    design = config['DESIGN_NAME']
+    verilog_path = config['VERILOG_FILES']
+    sdc_path = config['SDC_FILE']
+    core_left, core_bottom, core_right, core_top = config['CORE_AREA'].split(' ')
+    die_left, die_bottom, die_right, die_top = config['DIE_AREA'].split(' ')
+    platform = config['PLATFORM']
+
+    # Currently unused: ADDER_MAP_FILE (blank for gcd), ABC_AREA (not sure meaning?)
+    print(config)
+
+    chip = siliconcompiler.Chip(design)
+    chip.set('option', 'scpath', scdir)
+
+    chip.set('input', 'verilog', verilog_path)
+    chip.set('input', 'sdc', sdc_path)
+    chip.set('asic', 'diearea', [(die_left, die_bottom), (die_right, die_top)])
+    chip.set('asic', 'corearea', [(core_left, core_bottom), (core_right, core_top)])
+
+    # TODO: create OR specific targets
+    #chip.load_target(f'{platform}_or')
+
+    # For testing, TODO: put in run logic
+    chip.write_manifest(f'{design}.json')
+
+if __name__ == '__main__':
+    main()

--- a/flow/Makefile.py
+++ b/flow/Makefile.py
@@ -15,32 +15,25 @@ def main():
     args = vars(parser.parse_args())
 
     # Parse values out of provided "config.mk" file
-    # TODO: filled this out based on ./designs/nangate45/gcd/config.mk
-    # There are more possible variables and likely more complex possible values
-    # (such as multiple Verilog files)
     config = parse_config_mk.parse(args['DESIGN_CONFIG'])
     design = config['DESIGN_NAME']
-    verilog_path = config['VERILOG_FILES']
-    sdc_path = config['SDC_FILE']
-    core_left, core_bottom, core_right, core_top = config['CORE_AREA'].split(' ')
-    die_left, die_bottom, die_right, die_top = config['DIE_AREA'].split(' ')
-    platform = config['PLATFORM']
 
-    # Currently unused: ADDER_MAP_FILE (blank for gcd), ABC_AREA (not sure meaning?)
     print(config)
 
     chip = siliconcompiler.Chip(design)
     chip.set('option', 'scpath', scdir)
 
-    chip.set('input', 'verilog', verilog_path)
-    chip.set('input', 'sdc', sdc_path)
-    chip.set('asic', 'diearea', [(die_left, die_bottom), (die_right, die_top)])
-    chip.set('asic', 'corearea', [(core_left, core_bottom), (core_right, core_top)])
+    # TODO: should we actually fill out stuff in the schema, or just pass
+    # everything through?
+    for key, val in config.items():
+        chip.set('option', 'env', key, val)
 
-    # TODO: create OR specific targets
+    # TODO: should we create OR specific targets that then load associated PDKs/libs?
+    #platform = config['PLATFORM']
     #chip.load_target(f'{platform}_or')
 
-    # For testing, TODO: put in run logic
+    # For testing
+    # TODO: put in run logic
     chip.write_manifest(f'{design}.json')
 
 if __name__ == '__main__':

--- a/flow/scripts/sc/util/parse_config_mk.py
+++ b/flow/scripts/sc/util/parse_config_mk.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import tempfile
+
+def parse(path):
+    '''Parse env variables defined in a Makefile fragment'''
+    env_before = os.environ
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        makefile_path = os.path.join(tempdir, 'Makefile')
+        with open(makefile_path, 'w') as f:
+            print(f'include {path}', file=f)
+            print(f'all:', file=f)
+            print(f'\tprintenv', file=f)
+
+        proc = subprocess.run(['make', '-s', '--no-print-directory', '-f', makefile_path], stdout=subprocess.PIPE)
+        output = proc.stdout.decode('utf-8')
+
+    new_envvars = {}
+    assignments = output.split('\n')
+    for assignment in assignments:
+        if not assignment:
+            # skip blank lines
+            continue
+
+        var, val = assignment.split('=', 1)
+        if var in ('MAKEFLAGS', 'MFLAGS', 'MAKE_TERMERR', 'MAKE_TERMERR', 'MAKELEVEL'):
+            # skip envvars that Make adds
+            continue
+
+        if var not in env_before:
+            new_envvars[var] = val
+
+    return new_envvars
+
+if __name__ == '__main__':
+    vars = parse_config_mk('./designs/nangate45/bp_fe_top/config.mk')
+    print(vars)


### PR DESCRIPTION
This PR adds a simple Makefile "parser" utility for extracting environment variables out of a Makefile fragment. I also added a demo based on Andreas' suggestion of creating a parallel "Makefile.py" that has an interface analogous to the original Makefile.

For now, this Makefile.py just prints out a manifest, but we can port the run logic over from the heartbeat example as a next step.

Ex:
```
$ cd flow
$ python Makefile.py -DESIGN_CONFIG ./designs/nangate45/gcd/config.mk
``` 