### PR TITLE
Map step results into inputs/outputs directories

### DIFF
--- a/flow/scripts/sc/flows/orflow.py
+++ b/flow/scripts/sc/flows/orflow.py
@@ -37,39 +37,77 @@ def setup(chip, flowname='orflow'):
     # TODO: Use the 'import' step to parse config.mk file env vars.
     # TODO: Split up individual TCL scripts into sc tasks?
     flow = 'orflow'
-    flowpipe = {
-        'import': ['nop', ''],
-        'syn': ['openroad', 'yosys.tcl'], # (synthesis is done via OpenROAD TCL that calls yosys)
-        'init_floorplan': ['openroad', 'floorplan.tcl'],
-        'io_place_rand': ['openroad', 'io_placement_random.tcl'],
-        'tdms_place': ['openroad', 'tdms_place.tcl'],
-        'macro_place': ['openroad', 'macro_place.tcl'],
-        'tapcell': ['openroad', 'tapcell.tcl'],
-        'pdn': ['openroad', 'pdn.tcl'],
-        'gp_skip_io': ['openroad', 'global_place_skip_io.tcl'],
-        'io_place': ['openroad', 'io_placement.tcl'],
-        'global_place': ['openroad', 'global_place.tcl'],
-        'resize': ['openroad', 'resize.tcl'],
-        'detail_place': ['openroad', 'detail_place.tcl'],
-        'clock_tree_syn': ['openroad', 'cts.tcl'],
-        'fillcells': ['openroad', 'fillcell.tcl'],
-        'global_route': ['openroad', 'global_route.tcl'],
-        'detail_route': ['openroad', 'detail_route.tcl'],
-        'final_report': ['openroad', 'final_report.tcl'],
-        # Like yosys, KLayout GDS-streaming script is run through an OpenROAD tcl script
-        'export': ['openroad', 'klayout.tcl'],
+
+    flow_groups = {
+        'synthesis': [
+            ('or_yosys', 'openroad'), # (synthesis is done via OpenROAD TCL that calls yosys)
+        ],
+        'floorplan': [
+            ('or_floorplan', 'openroad'),
+            ('or_io_placement_random', 'openroad'),
+            ('or_tdms_place', 'openroad'),
+            ('or_macro_place', 'openroad'),
+            ('or_tapcell', 'openroad'),
+            ('or_pdn', 'openroad'),
+        ],
+        'place': [
+            ('or_global_place_skip_io', 'openroad'),
+            ('or_io_placement', 'openroad'),
+            ('or_global_place', 'openroad'),
+            ('or_resize', 'openroad'),
+            ('or_detail_place', 'openroad'),
+        ],
+        'cts': [
+            ('or_cts', 'openroad'),
+            ('or_fillcell', 'openroad'),
+        ],
+        'route': [
+            ('or_global_route', 'openroad'),
+            ('or_detail_route', 'openroad'),
+        ],
+        'finish': [
+            ('or_final_report', 'openroad'),
+            # Like yosys, KLayout GDS-streaming script is run through an OpenROAD tcl script
+            ('export', 'openroad')
+        ]
     }
-    last_step = ''
-    for k,v in flowpipe.items():
-        chip.node(flow, k, v[0])
-        if last_step:
-            chip.edge(flow, last_step, k)
-        if v[1]:
-            chip.set('tool', v[0], 'script', k, '0',
-                     os.path.abspath(os.path.join(openroad_dir, 'flow', 'scripts', v[1])))
-            chip.set('tool', v[0], 'refdir', k, '0', os.path.join('tools', v[0]))
-        last_step = k
+    flowpipe = ['synthesis', 'floorplan', 'place', 'cts', 'route', 'finish']
+
+    # Additional dependencies defined here
+    extra_deps = {
+        'or_detail_route': ['or_fillcell'], # reads 4_cts.odb
+    }
+
+    chip.node(flow, 'import', 'nop')
+    last_step = 'import'
+    last_sdc_step = ''
+    for group in flowpipe:
+        for step, tool in flow_groups[group]:
+            chip.node(flow, step, tool)
+
+            if last_step:
+                chip.edge(flow, last_step, step)
+            if last_sdc_step and last_sdc_step != last_step:
+                chip.edge(flow, last_sdc_step, step)
+            if step in extra_deps:
+                for dep in extra_deps[step]:
+                    chip.edge(flow, dep, step)
+
+            last_step = step
+
+            chip.set('tool', tool, 'script', step, '0', 'sc_apr.tcl')
+            chip.set('tool', tool, 'refdir', step, '0', os.path.join(openroad_dir, 'flow', 'scripts'))
+
+        # Each step in a flow group relies on an SDC produced by (or copied
+        # into) the first step of the previous flow group.
+        last_sdc_step, _ = flow_groups[group][0]
 
     # Set default goal
     for step in chip.getkeys('flowgraph', flow):
         chip.set('flowgraph', flow, step, '0', 'goal', 'errors', 0)
+
+if __name__ == '__main__':
+    chip = siliconcompiler.Chip('<design>')
+    setup(chip)
+    chip.set('option', 'flow', 'orflow')
+    chip.write_flowgraph('orflow.png')

--- a/flow/scripts/sc_apr.tcl
+++ b/flow/scripts/sc_apr.tcl
@@ -8,20 +8,26 @@ set sc_refdir [dict get $sc_cfg tool $sc_tool refdir $sc_step $sc_index]
 set results_dir $::env(RESULTS_DIR)
 set inputs [list]
 
+# Copy from inputs/ into OpenROAD work directory
 file mkdir $results_dir
 foreach f [glob -directory inputs/ -tails -nocomplain *] {
     file copy -force inputs/$f $results_dir
     lappend inputs $f
 }
 
+# Determine OR script name based on step name
 if {$sc_step == "export"} {
+    # export is special case
     set script "klayout.tcl"
 } else {
+    # strip or_ prefix
     set script [string replace $sc_step 0 2 ""].tcl
 }
 
+# Run script
 source $sc_refdir/$script
 
+# Copy anything from work dir that was not an input into outputs/
 foreach f [glob -directory $results_dir -tails -nocomplain *] {
     if {[lsearch $inputs $f] == -1} {
         file copy -force $results_dir/$f outputs/

--- a/flow/scripts/sc_apr.tcl
+++ b/flow/scripts/sc_apr.tcl
@@ -1,0 +1,29 @@
+source sc_manifest.tcl
+
+set sc_tool "openroad"
+set sc_step [dict get $sc_cfg arg step]
+set sc_index [dict get $sc_cfg arg index]
+set sc_refdir [dict get $sc_cfg tool $sc_tool refdir $sc_step $sc_index]
+
+set results_dir $::env(RESULTS_DIR)
+set inputs [list]
+
+file mkdir $results_dir
+foreach f [glob -directory inputs/ -tails -nocomplain *] {
+    file copy -force inputs/$f $results_dir
+    lappend inputs $f
+}
+
+if {$sc_step == "export"} {
+    set script "klayout.tcl"
+} else {
+    set script [string replace $sc_step 0 2 ""].tcl
+}
+
+source $sc_refdir/$script
+
+foreach f [glob -directory $results_dir -tails -nocomplain *] {
+    if {[lsearch $inputs $f] == -1} {
+        file copy -force $results_dir/$f outputs/
+    }
+}


### PR DESCRIPTION
This PR modifies our build script and flow to ensure that the results of each step end up in the correct inputs/ and outputs/ directories within the SC build directory structure.

Key changes & rationale
- For each task, the build script sets `$RESULTS_DIR` to point to `or_work/` within that task's directory. Each step's TCL script uses this env variable to determine where to read inputs and write outputs.
- There's now a single entrypoint, `sc_apr.tcl`, that is responsible for calling each OR flow script. This TCL script copies anything in `inputs/` into `or_work/`, runs the proper step script, and then copies any outputs in `or_work/` into `outputs/`.
  - The script snapshots input names to ensure that it doesn't keep copying inputs forward (this prevents the build directory size from exploding). 
  - I renamed the steps to `or_<tcl_script_name>` to make it easy to determine which scripts to source (I kept `export` a special case, since that's a standardized name). I think this is a reasonable change, since it's consistent with our methodology for our own reference scripts (the prefix is necessary to disambiguate some step names).
-  I needed to tweak the post-processing Python code after each flow group, now that the result files are inside the task directories.
- This change also unveiled some dependencies that aren't very explicit in the Makefile. In particular, it seems like each step in a given "flow group" relies on the SDC from the previous flow group, which is generally produced by the first step in the previous flow group. 
  - I figure we should express this dependency properly in the flowgraph (rather than copying things around), so I split the flow definition into the appropriate groups to keep the flow setup concise. 
  - To keep things consistent, for flow groups that copy forward/rename their SDC file (rather than generating it), I copied the file into the outputs of the first step of that flow group (this is a bit hacky, since this file doesn't get copied in until after that entire group runs, but it seemed ideal for now)

Still to be done:
- Handling the objects dir

Note: the flowgraph as set up now is technically illegal, since we don't allow feeding multiple inputs into a tool task (generally requires an explicit join). SC logs errors about this, but it actually seems to work... I'm going to investigate if we can make this a legal construct in SC, since adding joins would make the flow setup more complex. If SC can't be changed, I'll add the joins in.